### PR TITLE
Path can be specified via CLI argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,11 +15,11 @@ The go-code-visualizer will generate a gv(graphviz) file that can be visualized 
 How can i use it?
 =================
 
-Build the go code into an executable.
+`go run go-code-visualizer.go <path>`
 
-Run the executable in the folder of the project you want to visualize.
+Alternatively, you can also build the go code into an executable and place it in the folder of the project you want to visualize.
 
-It will put a .gv file in the same folder
+Program will produce a .gv file in the analyzed folder
 
 Place the contents of the .gv file in this(http://mdaines.github.io/viz.js/) online visualizer.
 

--- a/go-code-visualizer.go
+++ b/go-code-visualizer.go
@@ -2,8 +2,8 @@ package main
 
 import (
 	"bufio"
-	"github.com/codehipster/go-code-visualizer/parser"
 	"github.com/codehipster/go-code-visualizer/formatter"
+	"github.com/maelkum/go-code-visualizer/parser"
 	"log"
 	"os"
 	"path/filepath"
@@ -18,13 +18,24 @@ func check(e error) {
 
 func main() {
 
-	//Get current directory
-	dir, err := filepath.Abs(filepath.Dir(os.Args[0]))
-	if err != nil {
-		log.Fatal(err)
+	var dir string
+
+	if len(os.Args) > 1 {
+		dir = os.Args[1]
+	} else {
+
+		// get directory where binary is located if no args
+		// CWD makes more sense but let's keep existing behaviour as-is
+
+		exe_dir, err := filepath.Abs(filepath.Dir(os.Args[0]))
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		dir = exe_dir
 	}
 
-	parsedGoCodeFiles := make([]formatter.ParsedCode,0)
+	parsedGoCodeFiles := make([]formatter.ParsedCode, 0)
 
 	//walk the filesystem.
 	walkFunc := func(path string, info os.FileInfo, err error) error {
@@ -51,7 +62,7 @@ func main() {
 	check(err)
 	defer cvFile.Close()
 	
-	writer := bufio.NewWriter(cvFile)	
+	writer := bufio.NewWriter(cvFile)
 	
 	writer.WriteString(dotGraph)
 	writer.Flush()

--- a/parser/ast-scanner.go
+++ b/parser/ast-scanner.go
@@ -35,13 +35,19 @@ func goParseFile(path string) (ast *ast.File){
 	return
 }
 
+/*
+   If package is located under src, return path relative to it. Keep path complete if not
+   TODO: src can be anything, not exclusive to GOPATH
+*/
+func distilPackagePath(path string) string {
+	directory := filepath.Dir(path)
+	srcIndex := strings.Index(directory, "src")
 
-//TODO: assuming the code resides in a src folder. is that always true?
-//TODO: what if index is -1?
-func distilPackagePath(path string) string {	
-    directory := filepath.Dir(path)
-    srcIndex := strings.Index(directory,"src")
-    return filepath.ToSlash(directory[srcIndex+4:])
+	if -1 != srcIndex {
+		return filepath.ToSlash(directory[srcIndex+4:])
+	}
+
+	return filepath.ToSlash(directory)
 }
 
 func parseImportDeclarations(importSpecs []ast.Spec) []string{


### PR DESCRIPTION
Script can function as before - build into an executable and copy it
to the folder containing the code to be analyzed. However, an
alternative is available, as now the path can be specified as a
command line argument.